### PR TITLE
4.14 noname fixes

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -168,6 +168,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
   {USB_DEVICE(0x0789, 0x016E), .driver_info = RTL8812}, /* Logitec - Edimax */
   {USB_DEVICE(0x07B8, 0x8812), .driver_info = RTL8812}, /* Abocom - Abocom */
   {USB_DEVICE(0x0B05, 0x17D2), .driver_info = RTL8812}, /* ASUS - Edimax */
+  {USB_DEVICE(0x0BDA, 0x8812), .driver_info = RTL8812}, /* KOOTEK */
   {USB_DEVICE(0x0DF6, 0x0074), .driver_info = RTL8812}, /* Sitecom - Edimax */
   {USB_DEVICE(0x0E66, 0x0022), .driver_info = RTL8812}, /* HAWKING - Edimax */
   {USB_DEVICE(0x1058, 0x0632), .driver_info = RTL8812}, /* WD - Cybertan */

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2023,8 +2023,10 @@ static int readFile(struct file *fp, char *buf, int len)
 		return -EPERM;
 
 	while (sum < len) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0))
 		rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+		rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
 #else
 		rlen = fp->f_op->read(fp, buf + sum, len - sum, &fp->f_pos);
 #endif


### PR DESCRIPTION
Hi,

I added another USB ID (generic Realtek device, branded with 'KOOTEK': https://www.amazon.co.uk/Kootek-Wireless-AC1200-Detachable-10-6-10-12/dp/B01N74KJ6K) and replaced the __vfs_read method with kernel_read (__vfs_read is not exported any more in 4.14).