### PR TITLE
Add Raspberry Pi support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 CONFIG_MP_VHT_HW_TX_MODE = n
 ###################### Platform Related #######################
 CONFIG_PLATFORM_I386_PC = y
+CONFIG_PLATFORM_ARM_RPI = n
 CONFIG_PLATFORM_ANDROID_X86 = n
 CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
 CONFIG_PLATFORM_JB_X86 = n
@@ -1010,6 +1011,15 @@ KSRC ?= /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
 STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
+endif
+
+ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ARCH ?= arm
+CROSS_COMPILE ?=
+KVER := $(shell uname -r)
+KSRC ?= /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 endif
 
 ifeq ($(CONFIG_PLATFORM_NV_TK1), y)


### PR DESCRIPTION
See 333330f6a73f0510e36020c9e624f8a7a285a118.

Add `CONFIG_PLATFORM_ARM_RPI` to the makefile.  
The settings are directly taken from [the `Makefile` in gnab/rtl8812au](https://github.com/gnab/rtl8812au/blob/master/Makefile).

Tested on Raspberry Pi 3 with `Linux 4.14.62-v7+`.