### PR TITLE
Correct ARCH= setting on arm64.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1005,7 +1005,7 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/aarch64/arm64/ )
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER ?= $(shell uname -r)


### PR DESCRIPTION
uname prints aarch64, but kernel headers arch is called arm64. This
sed, fixes out-of-the-box building dkms module on ARM64 laptops.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>